### PR TITLE
Désactiver le scan nuclei

### DIFF
--- a/.github/workflows/scans.yml
+++ b/.github/workflows/scans.yml
@@ -217,7 +217,7 @@ jobs:
       - name: Nuclei scan
         if: ${{ matrix.sites.tools.nuclei }}
         continue-on-error: true
-        timeout-minutes: 10
+        timeout-minutes: 15
         uses: "SocialGouv/dashlord-nuclei-action@master"
         with:
           url: ${{ matrix.sites.url }}

--- a/dashlord.yml
+++ b/dashlord.yml
@@ -84,7 +84,7 @@ tools:
   lighthouse: true
   testssl: true
   wappalyzer: true
-  nuclei: true
+  nuclei: false
   zap: true
   thirdparties: true
   dependabot: true


### PR DESCRIPTION
Comme dit sur Mattermost, aujourd'hui ce scan échoue quasi-systématiquement, alors qu'il coûte très cher en compute (30 à 50% du temps d'exécution des scans Dashlord).

Cette PR augmente le timeout à 15 minutes pour éviter les crashs, mais désactive carrément le check nuclei comme dans le Dashlord de la DINUM.